### PR TITLE
Fix incorrect ceph connected requirement

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -63,7 +63,7 @@ class AuthController extends Controller
      public function login(LoginRequest $request, RequestApiService $requestApiService)
     {
         $result = json_decode($requestApiService->request('GET', 'bucket', "?format=json"));
-        if (is_object($result) || empty($result)) {
+        if (is_array($result)) {
           return response()->json(['message' => 'Connection to Ceph failed'], 403);
         }
         $data = $this->users->verify($request->all());
@@ -96,7 +96,7 @@ class AuthController extends Controller
     public function checkCephConnected(RequestApiService $requestApiService)
     {
         $result = json_decode($requestApiService->request('GET', 'bucket', "?format=json"));
-        if (is_object($result) || empty($result)) {
+        if (is_array($result)) {
             return response()->json(['message' => 'Connection to Ceph failed'], 403);
         } else {
             return  response()->json(['message' => 'Connected to Ceph success'], 200);


### PR DESCRIPTION
Because RADOSGW Admin API is return null when s3 connect ceph is failed, so change function from is_object to is_array.